### PR TITLE
Add role and preferred languages field to the sign up form

### DIFF
--- a/homeapp/admin.py
+++ b/homeapp/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django_summernote.admin import SummernoteModelAdmin
-from .models import ContactRequest, CustomUser, ForumPost, Mentorship, Message, Reply
+from .models import ContactRequest, CustomUser, ForumPost, Mentorship, Message, Reply, Language
 
 @admin.register(CustomUser)
 class CustomUserAdmin(admin.ModelAdmin):
@@ -34,3 +34,7 @@ class MessageAdmin(admin.ModelAdmin):
 class ContactRequestAdmin(admin.ModelAdmin):
     list_display = ('name', 'email', 'subject', 'created_at')
     search_fields = ('name', 'email', 'subject', 'message')
+
+@admin.register(Language)
+class LanguageAdmin(admin.ModelAdmin):
+    list_display = ('name',)

--- a/homeapp/forms.py
+++ b/homeapp/forms.py
@@ -3,8 +3,11 @@ from .models import ForumPost, Mentorship, CustomUser, Language
 from django import forms
 from allauth.account.forms import SignupForm
 
-#sign up form
+
 class CustomSignupForm(SignupForm):
+    '''
+    Custom signup form to include role and preferred languages.
+    '''
     role = forms.ChoiceField(
     choices=CustomUser.ROLE_CHOICES, 
     required=True, 

--- a/homeapp/forms.py
+++ b/homeapp/forms.py
@@ -5,9 +5,12 @@ from allauth.account.forms import SignupForm
 
 #sign up form
 class CustomSignupForm(SignupForm):
-    role = forms.ChoiceField(choices=CustomUser.ROLE_CHOICES, required=True, label='Role')
+    role = forms.ChoiceField(
+    choices=CustomUser.ROLE_CHOICES, 
+    required=True, 
+    label='Role')
     preferred_languages = forms.ModelMultipleChoiceField(
-        queryset=Language.objects.all(),  # Queryset for the Language model
+        queryset=Language.objects.all(), 
         required=False,
         widget=forms.CheckboxSelectMultiple,
         label='Preferred Languages'

--- a/homeapp/forms.py
+++ b/homeapp/forms.py
@@ -1,5 +1,30 @@
 from django import forms
-from .models import ForumPost, Mentorship
+from .models import ForumPost, Mentorship, CustomUser, Language
+from django import forms
+from allauth.account.forms import SignupForm
+
+#sign up form
+class CustomSignupForm(SignupForm):
+    role = forms.ChoiceField(choices=CustomUser.ROLE_CHOICES, required=True, label='Role')
+    preferred_languages = forms.ModelMultipleChoiceField(
+        queryset=Language.objects.all(),  # Queryset for the Language model
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        label='Preferred Languages'
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(CustomSignupForm, self).__init__(*args, **kwargs)
+        self.fields['role'].widget.attrs.update({'class': 'form-control'})
+        self.fields['preferred_languages'].widget.attrs.update({'class': 'form-control'})
+
+    def save(self, request):
+        user = super(CustomSignupForm, self).save(request)
+        user.role = self.cleaned_data['role']
+        user.preferred_languages.set(self.cleaned_data['preferred_languages'])
+        user.save()
+        return user
+
 
 class ForumPostForm(forms.ModelForm):
     class Meta:

--- a/techforher/settings.py
+++ b/techforher/settings.py
@@ -53,6 +53,13 @@ INSTALLED_APPS = [
     'homeapp',
 ]
 
+#Sign up form
+
+
+ACCOUNT_FORMS = {
+    'signup': 'homeapp.forms.CustomSignupForm',
+}
+
 SITE_ID = 1
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'

--- a/techforher/settings.py
+++ b/techforher/settings.py
@@ -55,7 +55,6 @@ INSTALLED_APPS = [
 
 #Sign up form
 
-
 ACCOUNT_FORMS = {
     'signup': 'homeapp.forms.CustomSignupForm',
 }


### PR DESCRIPTION
Had to add languages manually in the admin panel. Sign up still doesn't work, but we're a step closer.